### PR TITLE
Avoid duplicating the description from an if, while, or repeat on its first condition

### DIFF
--- a/dashboard/html/modules/piston.module.html
+++ b/dashboard/html/modules/piston.module.html
@@ -616,7 +616,7 @@
 		<bar ng-if="(mode=='edit') || (collection.c && (collection.c.length > 1))"></bar>
 		<trace ng-if="(view.trace && (mode=='view') && (collection.c) && (collection.c.length > 1) && trace && trace.points && trace.points['c:' + collection.$])"><span>+{{point.o}}ms</span><span dur eval="{{trace.points['c:' + collection.$].v}}">{{point.d}}ms</span></trace>
 		<div no-drag class="no-drag" dnd-list="collection.c" dnd-allowed-types="['condition']" ng-selected="selection == collection">
-			<line com ng-if="collection.z">/* {{collection.z}} */</line>
+			<line com ng-if="collection.z && (collection.t == 'group || collection.t == 'condition')">/* {{collection.z}} */</line>
 			<line pun data-ng-if-start="(collection.t == 'group') || !!collection.n" ng-click="select(collection, (collection.t == 'group' ? ($parent.$parent.parentCollection ? $parent.$parent.parentCollection.c : statement.c) : null), 'conditions')"><span pun ng-click="editConditionGroup(collection, (collection.t == 'group' ? ($parent.$parent.parentCollection ? $parent.$parent.parentCollection.c : statement.c) : null));">{{collection.n ? 'not ' : ''}}(</span><span ng-if="view.trace && (mode=='view')" nul> /* #{{collection.$}} */</span></line>
 			<container dnd-list="collection.c" dnd-allowed-types="['condition']">
 				<condition data-ng-repeat-start="condition in collection.c" ng-init="parentCollection = collection" data-ng-include="'condition'" dnd-nodrag data-nag-model="collection.c" dnd-draggable="condition" dnd-nodrag dnd-type="'condition'" dnd-moved="drag(collection.c, $index);" dnd-effect-allowed="copyMove"></condition>


### PR DESCRIPTION
I like to keep my pistons documented but I noticed that the description of an `if` was being duplicated on its first condition. This is due to passing `[statement]` to the conditions directive where `statement` represents the outer `if`, `while`, or `repeat`.

![duplicate comment](https://user-images.githubusercontent.com/507058/27345320-3e4eaadc-55b7-11e7-9294-17cc81c026f5.png)

The change ensures that comments are only displayed when the collection represents either a `condition` or `group` type:

![correct comment](https://user-images.githubusercontent.com/507058/27345383-7ab0ac1e-55b7-11e7-8dbe-b1c579e88e98.png)

Are pull requests a good way to contribute small fixes like this? I am unfamiliar with the requirements for versioning and ST GitHub updating but would like to help whenever I notice something. 