### PR TITLE
Always uri-encode base64 URI params to avoid decoding errors

### DIFF
--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -874,7 +874,7 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 				});
 		} else {
 			status('Saving piston...');
-	    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/piston/set?id=' + piston.id + '&data=' + data + '&bin=' + encodeURIComponent(binId) + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
+	    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/piston/set?id=' + piston.id + '&data=' + encodeURIComponent(data) + '&bin=' + encodeURIComponent(binId) + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
 				.then(function(response) {
 					status();
 					return response;
@@ -947,7 +947,7 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 		var inst = dataService.getInstance();
 		si = store ? store[inst.id] : null;
 		var data = value ? utoa(angular.toJson(value)) : '';
-    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/variable/set?name=' + name + '&value=' + data + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
+    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/variable/set?name=' + name + '&value=' + encodeURIComponent(data) + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
 			.then(function(response) {
 				return response.data;
 			});
@@ -957,7 +957,7 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 		var inst = dataService.getInstance();
 		si = store ? store[inst.id] : null;
 		var data = settings ? utoa(angular.toJson(settings)) : '';
-    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/settings/set?settings=' + data + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
+    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/settings/set?settings=' + encodeURIComponent(data) + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
 			.then(function(response) {
 				return response.data;
 			});
@@ -968,7 +968,7 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 		if (!inst) { inst = dataService.getInstance() };
 		si = store ? store[inst.id] : null;
 		var data = utoa(angular.toJson(expression));
-    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/piston/evaluate?id=' + pid + '&expression=' + data + '&dataType=' + (dataType ? encodeURIComponent(dataType) : '') + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
+    	return $http.jsonp((si ? si.uri : 'about:blank/') + 'intf/dashboard/piston/evaluate?id=' + pid + '&expression=' + encodeURIComponent(data) + '&dataType=' + (dataType ? encodeURIComponent(dataType) : '') + '&token=' + (si && si.token ? si.token : ''), {jsonpCallbackParam: 'callback'})
 			.then(function(response) {
 				return response.data;
 			});


### PR DESCRIPTION
I stumbled across an ISE when evaluating expressions and saving small pistons. Consider the following expressions, outwardly there seems to be no reason why one would work and the other cause an ISE:
```
223599 > 0    // works
2235993 > 0   // throws groovy.json.JsonException
```

Expressions are converted from JSON to base64 on the client side, then set as a query parameter. However, that base64 value is not URL encoded so characters like `=` and `+` are passed through. The backend then URL-decodes the parameter, replacing `+` with a space character and breaking the base64 decoding.

The most important request that saves large, chunked pistons already encoded the parameter. This pull request adds the same encoding to saving unchunked pistons, evaluating expressions, and setting variables and settings. Hopefully this is all that is needed to prevent the ISE's on these endpoints when the right sequence of bits are encoded.