### PR TITLE
Allow color temperature fades from 1000 to 30000K rather than 0 to 100

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -2562,8 +2562,8 @@ private long vcmd_fadeColorTemperature(rtData, device, params) {
     if (state && (getDeviceAttributeValue(rtData, device, 'switch') != "$state")) {
         return 0
     }
-    startLevel = (startLevel < 0) ? 0 : ((startLevel > 100) ? 100 : startLevel)
-    endLevel = (endLevel < 0) ? 0 : ((endLevel > 100) ? 100 : endLevel)
+    startLevel = (startLevel < 1000) ? 1000 : ((startLevel > 30000) ? 30000 : startLevel)
+    endLevel = (endLevel < 1000) ? 1000 : ((endLevel > 30000) ? 30000 : endLevel)
     return vcmd_internal_fade(rtData, device, 'setColorTemperature', startLevel, endLevel, duration)
 }
 


### PR DESCRIPTION
This is a simple fix for a [community bug report](https://community.webcore.co/t/emulated-fade-color-temperature-action-not-working/745/3). `fadeColorTemperature` was restricting the color temperature value to a range of 0 to 100.

This change extends that range to match `adjustColorTemperature`, from 1000 to 30000K.