### PR TITLE
Fixes several issues with local HTTP requests

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3154,7 +3154,7 @@ public localHttpRequestHandler(physicalgraph.device.HubResponse hubResponse) {
     if (binary) {
 		setRtData.mediaType = mediaType
 		setRtData.mediaData = data?.getBytes()
-    } else {
+    } else if (data) {
         try {
             def trimmed = data.trim()
             if (trimmed.startsWith('{') && trimmed.endsWith('}')) {

--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3153,10 +3153,11 @@ public localHttpRequestHandler(physicalgraph.device.HubResponse hubResponse) {
 		setRtData.mediaData = data?.getBytes()
     } else {
         try {
-            if (data.startsWith('{') && data.endsWith('}')) {
-                    json = (LinkedHashMap) new groovy.json.JsonSlurper().parseText(data)
-                } else if (data.startsWith('[') && data.endsWith(']')) {
-                    json = (List) new groovy.json.JsonSlurper().parseText(data)
+            def trimmed = data.trim()
+            if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+                    json = (LinkedHashMap) new groovy.json.JsonSlurper().parseText(trimmed)
+                } else if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+                    json = (List) new groovy.json.JsonSlurper().parseText(trimmed)
                 } else {
                     json = [:]
                 }

--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3168,7 +3168,7 @@ public localHttpRequestHandler(physicalgraph.device.HubResponse hubResponse) {
             json = [:]
         }
     }
-	handleEvents([date: new Date(), device: location, name: 'wc_async_reply', value: 'httpRequest', jsonData: json, responseCode: responseCode, setRtData: setRtData])
+	handleEvents([date: new Date(), device: location, name: 'wc_async_reply', value: 'httpRequest', contentType: mediaType, responseData: data, jsonData: json, responseCode: responseCode, setRtData: setRtData])
 }
 
 private long vcmd_httpRequest(rtData, device, params) {

--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -828,7 +828,10 @@ def handleEvents(event) {
         //schedules.removeAll{ (it.t <= threshold) && (it.s == event.schedule.s) && (it.i == event.schedule.i) }
         schedules.remove(event.schedule)
         if (event.name == 'wc_async_reply') {
-        	if (event.schedule.stack) event.schedule.stack.response = event.jsonData
+        	if (event.schedule.stack) {
+              event.schedule.stack.response = event.responseData
+              event.schedule.stack.json = event.jsonData
+            }
             event.name = 'time'
             event.value = now()
             int responseCode = cast(rtData, event.responseCode, 'integer')

--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3141,7 +3141,7 @@ public localHttpRequestHandler(physicalgraph.device.HubResponse hubResponse) {
     }
     
     def binary = false
-    def mediaType = hubResponse.getHeaders()['content-type']?.toLowerCase()
+    def mediaType = hubResponse.getHeaders()['content-type']?.toLowerCase().tokenize(';')[0]
     switch (mediaType) {
         case 'image/jpeg':
         case 'image/png':


### PR DESCRIPTION
From https://community.webcore.co/t/xml-response-handling-from-web-request/878/31

PR just for ease of seeing the changes; showing bits of code in Discourse was not working well for this one.

### `$httpContentType` is null
The `wc_async_reply` event is expecting a `contentType` parameter but `localHttpRequestHandler` does not provide it. Added `contentType: mediaType` to the event data.

### `mediaType` can include charset and boundary
`mediaType` in `localHttpRequestHandler` is just the Content-Type header; the charset needs to be removed (i.e. passing `contentType: mediaType` gives me a value of `application/json; charset=utf-8`.

```groovy
def mediaType = hubResponse.getHeaders()['content-type']?.toLowerCase().tokenize(';')[0]
```

### `response.body` is not available
The `localHttpRequestHandler` does not pass along the response body, only any json that is parsed from it. Instead, both the json and raw response body should be passed. Note that changes to `wc_async_reply` could also affect `asyncHttpRequestHandler` but it didn't look like anything would break.

Tweaked `localHttpRequestHandler` to pass `responseData: data, jsonData: json` then updated the event handler. 

```groovy
if (event.schedule.stack) {
  event.schedule.stack.response = event.responseData
  event.schedule.stack.json = event.jsonData
}
```

### json response can't have leading or trailing whitespace
The `startsWith` and `endsWith` calls should operate on a trimmed value:
```groovy
def trimmed = data.trim()
if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
    json = (LinkedHashMap) new groovy.json.JsonSlurper().parseText(trimmed)
} else if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
    json = (List) new groovy.json.JsonSlurper().parseText(trimmed)
} else {
    json = [:]
}
```

`hubResponse.json` may be simpler option here, but maybe not. It caused problems when I tried to parse JSON data that is not an array or object (e.g. `"text"` or `5` or `null`)

### Is `$response.data.*` a thing?

I thought I remembered `$response.data.*` being used to access JSON values, like `{"test": "test"}` accessed as `$response.data.test`, but I think I was mistaken because I couldn't find any code that does it. If that does happen for normal requests this PR does not address it for locals, you would access the request with `$response.test` (which I think is the correct way anyway, just making sure).