### PR TITLE
Schedule the next occurrence with respect to restrictions

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -1935,22 +1935,17 @@ private scheduleTimeCondition(rtData, condition) {
     def v2 = trigger ? v1 : ((comparison.p > 1) ? (evaluateExpression(rtData, evaluateOperand(rtData, null, condition.ro2, null, false, true), 'datetime').v + (tv2 ? evaluateExpression(rtData, [t: 'duration', v: tv2.v, vt: tv2.vt]).v : 0)) : (condition.lo.v == 'time' ? getMidnightTime(rtData) : v1))
     def n = now() + 2000
     if (condition.lo.v == 'time') {
-    	//v1 = (v1 % 86400000) + getMidnightTime()
-    	//v2 = (v2 % 86400000) + getMidnightTime()
 	    while (v1 < n) v1 += 86400000
     	while (v2 < n) v2 += 86400000
-/*        int cnt = 100
-        error "checking restrictions for $condition.lo", rtData
-        while (cnt) {
-        	//repeat until we find a day that's matching the restrictions
-	    	n = v1 < v2 ? v1 : v2
-			if (checkTimeRestrictions(rtData, condition.lo, n, 5, 1) == 0) break
-            long n2 = localToUtcTime(utcToLocalTime(n) + 86400000)
-            error "adding a day, $n >>> $n2", rtData
-            v1 = (v1 == n) ? n2 : v1
-            v2 = (v2 == n) ? n2 : v2
-            cnt = cnt - 1
-        }*/
+      int cnt = 366
+      while (cnt) {
+        //repeat until we find a day that's matching the restrictions
+        n = v1 < v2 ? v1 : v2
+        if (checkTimeRestrictions(rtData, condition.lo, n, 5, 1) == 0) break
+        v1 = localToUtcTime(utcToLocalTime(v1) + 86400000)
+        v2 = localToUtcTime(utcToLocalTime(v2) + 86400000)
+        cnt = cnt - 1
+      }
     }
     //figure out the next time
     v1 = (v1 < n) ? v2 : v1


### PR DESCRIPTION
This change avoids unexpected wakeups of a piston containing a time condition with restrictions. The condition is evaluated correctly according to the restrictions, but the scheduling is set for every day regardless of the restriction.

In the following example [reported here](https://community.webcore.co/t/task-being-sent-when-it-shouldnt-be/3174) the piston wakes at 23:30:00 every day of the week, despite the condition restriction to Friday, Saturday, or Sunday.
![](https://community.webcore.co/uploads/default/original/2X/e/e12422706df430ae94ca7586c28c76cc8edd11c5.png)

There was some code commented out on which this change was based so it is very possible that a problem was discovered back in April (790069395ddc3425903929aea0002f65ffa17654). The modified code should skip to the next non-restricted day and also handle far-future schedules (i.e. > 100 days away).

Review is definitely needed here to avoid negatively affecting other schedules.