### PR TITLE
Fixed subscripting array with $index when $index is 0.0

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -5061,7 +5061,9 @@ private Map getVariable(rtData, name) {
         	Map indirectVar = getVariable(rtData, var.index)
             //indirect variable addressing
             if (indirectVar && (indirectVar.t != 'error')) {
-            	var.index = cast(rtData, indirectVar.t == 'decimal' ? cast(rtData, indirectVar.v, 'integer', indirectVar.t) : indirectVar.v, 'string', indirectVar.t)
+                def value = indirectVar.t == 'decimal' ? cast(rtData, indirectVar.v, 'integer', indirectVar.t) : indirectVar.v
+                def dataType = indirectVar.t == 'decimal' ? 'integer' : indirectVar.t
+                var.index = cast(rtData, value, 'string', dataType)
             }
         	result.v = result.v[var.index]
 //        } else {


### PR DESCRIPTION
Fixes #25 which was caused by casting `$index` from a decimal to an integer to a string, but as if the integer were still a decimal. Given an integer but expecting a decimal, `cast` returned `null` for the index.

The temporary workaround for this was to use an integer variable for the loop counter or to–gasp–use 1-based arrays.