### PR TITLE
Update substring function parameter in webcore-piston.groovy

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3217,7 +3217,7 @@ private long vcmd_httpRequest(rtData, device, params) {
 	def internal = uri.startsWith("10.") || uri.startsWith("192.168.")
 	if ((!internal) && uri.startsWith("172.")) {
 		//check for the 172.16.x.x/12 class
-		def b = uri.substring(4,2)
+		def b = uri.substring(4,6)
 		if (b.isInteger()) {
 			b = b.toInteger()
 			internal = (b >= 16) && (b <= 31)


### PR DESCRIPTION
Updated substring parameters used to identify RFC1918 IP addresses in the 172.16.0.0 – 172.31.255.255 address range.  Without this change a Java error is thrown when using a 172.x.x.x IP address for the HTTP request because the endIndex parm for the substring function occurs before the beginIndex parm.