### PR TITLE
Hourly timers were scheduling for every n - 1 hours

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -1814,7 +1814,7 @@ private scheduleTimer(rtData, timer, long lastRun = 0) {
 
     if (intervalUnit == 'h') {
     	long min = cast(rtData, timer.lo.om, 'long')
-    	nextSchedule = (long) 3600000 * (Math.floor(nextSchedule / 3600000) - 1) + (min * 60000)
+    	nextSchedule = (long) 3600000 * Math.floor(nextSchedule / 3600000) + (min * 60000)
     }
 
     //next date


### PR DESCRIPTION
Hourly timer scheduling was running one hour earlier than expected; a timer for every 3 hours ran every 2 hours.

Reported in the community forums as [Timer Set For Every 3 Hours Running Every 2 Hours. Possible Bug?](https://community.webcore.co/t/timer-set-for-every-3-hours-running-every-2-hours-possible-bug/3648)