### PR TITLE
Avoid skipping the first occurrence when scheduling month and year timers 

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -1807,7 +1807,7 @@ private scheduleTimer(rtData, timer, long lastRun = 0) {
     lastRun = lastRun ? utcToLocalTime(lastRun) : rightNow
     long nextSchedule = lastRun
 
-    if (lastRun >= rightNow) {
+    if (lastRun > rightNow) {
     	//sometimes ST runs timers early, so we need to make sure we're at least in the near future
     	rightNow = lastRun + 1
     }


### PR DESCRIPTION
Some timers schedule such that if the target has already passed in the current time period the next time period is used instead. For example, today is Dec 28 so a timer for every Jan 1 will be correctly scheduled for 2018 rather than 2017. However, in some cases the opposite condition where the target *has not yet passed* in the current time period was not working properly. This seems to only affect month and year timers.

A few examples of behavior that is fixed by this pull request:
* `every last day of the month` always schedules for the last day of the following month
* `every December 31st` always schedules for Dec 31st of the following year
* `every last Friday of May` always schedules for the following year

When the piston is saved, `lastRun` is zero so the line `lastRun = lastRun ? utcToLocalTime(lastRun) : rightNow` always sets `lastRun` and `rightNow` equal in that case. However, a few lines down the values were updated with `rightNow = lastRun + 1`. This caused scheduling logic that relied on `nextSchedule < rightNow` to always skip the next occurrence.

Originally reported in the community forums as [[BUG?] Using timer statement every 1 year always schedule next run in 2018 even if selected date is not passed in 2017](https://community.webcore.co/t/bug-using-timer-statement-every-1-year-always-schedule-next-run-in-2018-even-if-selected-date-is-not-passed-in-2017/813)