### PR TITLE
Fixes empty device dropdowns in piston restore for certain attributes

### DIFF
--- a/dashboard/js/modules/piston.module.js
+++ b/dashboard/js/modules/piston.module.js
@@ -636,6 +636,22 @@ config.controller('piston', ['$scope', '$rootScope', 'dataService', '$timeout', 
 
 	$scope.listDevicesWithAttributes = function(attributes) {
 		if (!attributes || !(attributes instanceof Array) || !attributes.length) return $scope.instance.devices;
+		// Virtual status attribute is available on all devices
+		if (attributes.length === 1 && attributes[0] === statusAttribute) return $scope.instance.devices;
+		// Use threeAxis instead of attributes derived from it
+		var isThreeAxis;
+		attributes = attributes.filter(function(a) {
+			switch (a) {
+				case 'orientation':
+				case 'axisX':
+				case 'axisY':
+				case 'axisZ':
+					isThreeAxis = true;
+				case statusAttribute:
+					return false;
+			}
+			return true;
+		}).concat(isThreeAxis ? 'threeAxis' : []);
 		var result = {};
 		for (d in $scope.instance.devices) {
 			var device = $scope.instance.devices[d];


### PR DESCRIPTION
Originally reported [here](https://community.webcore.co/t/did-restore-a-piston-using-a-backup-code-change-today/4056), the device dropdown for restoring from a backup bin is always empty for devices for which the piston uses the `$status`, `axisX`, `axisY`, `axisZ`, or `orientation` attributes. These are all virtual attributes derived from the device data.

### `$status`

All devices have a virtual `$status` attribute. When the **only** attribute used on a device in a piston is `$status`, all devices are eligible for selection when restoring the piston. When `$status` is used in addition to other attributes on a device the `$status` value is simply removed from the attribute search leaving the remaining attributes to filter the device list.

### `axisX`, `axisY`, `axisZ`, and `orientation`

These attributes are derived from `threeAxis`. When a device uses any one or more of these attributes all are removed from the attribute search and replaced with just the single `threeAxis` attribute.