### PR TITLE
Display evaluation of duration expressions in terms of the selected unit rather than milliseconds

### DIFF
--- a/dashboard/js/modules/piston.module.js
+++ b/dashboard/js/modules/piston.module.js
@@ -5128,6 +5128,18 @@ config.controller('piston', ['$scope', '$rootScope', 'dataService', '$timeout', 
 		operand.eval = '...';
 		var expression = operand.data.exp;
 		var dataType = operand.data.vt;
+		// Display durations relative to the selected unit; otherwise the expression
+		// will evaluate and return in terms of milliseconds.
+		switch (dataType) {
+			case 's':
+			case 'm':
+			case 'h':
+			case 'd':
+			case 'w':
+			case 'n':
+			case 'y':
+				dataType = 'ms';
+		}
 		$timeout.cancel(operand.tmrDelayEvaluation);
 		operand.tmrDelayEvaluation = $timeout(function() { if ($scope.designer && $scope.designer.dialog) {operand.eval = '(evaluating)'; evaluateExpression(expression, dataType, operand);}}, 2500);
 	}


### PR DESCRIPTION
When a duration expression is evaluated for the purpose of scheduling, it is evaluated in terms of milliseconds. However, the same evaluation is also displayed when entering the expression. So the simple expression `1 second` evaluates to `1000`. The problem is far less obvious when math and variables are involved.

![is it 1 or 1000](https://user-images.githubusercontent.com/507058/34739237-a8d9e524-f549-11e7-82cf-702d036e7cfb.png)

This pull request changes all duration units to milliseconds on the frontend when calculating this expression for display. I was not able to find any cases where this problem affects other expressions.

![1 == 1 so that's better](https://user-images.githubusercontent.com/507058/34739427-3d522f7c-f54a-11e7-8643-405819d710b9.png)


This has been reported numerous times:
* [Why won’t my piston trigger?](https://community.webcore.co/t/why-wont-my-piston-trigger-offset-expression-displays-incorrect-value-for-any-unit-other-than-milliseconds/2321)
* [Vacation light help](https://community.webcore.co/t/vacation-light-help/3812)
* [Webcore variable problem bug? ](https://community.webcore.co/t/webcore-variable-problem-bug/3466)