### PR TITLE
Fix NullPointerException when ST does not provide a sunset and sunrise

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -7701,6 +7701,11 @@ private initSunriseAndSunset(rtData) {
     def rightNow = localTime()
     if (!rtData.sunTimes) {
     	def sunTimes = app.getSunriseAndSunset()
+        if (!sunTimes.sunrise) {
+            warn "Actual sunrise and sunset times are unavailable; please reset the location for your hub", rtData
+            sunTimes.sunrise = new Date(getMidnightTime() + 7 * 3600000)
+            sunTimes.sunset = new Date(getMidnightTime() + 19 * 3600000)
+        }
         rtData.sunTimes = [
     		sunrise: sunTimes.sunrise.time,
     		sunset: sunTimes.sunset.time,

--- a/smartapps/ady624/webcore.src/webcore.groovy
+++ b/smartapps/ady624/webcore.src/webcore.groovy
@@ -1933,6 +1933,11 @@ private registerInstance() {
 
 private initSunriseAndSunset() {
     def sunTimes = app.getSunriseAndSunset()
+    if (!sunTimes.sunrise) {
+        warn "Actual sunrise and sunset times are unavailable; please reset the location for your hub", rtData
+        sunTimes.sunrise = new Date(getMidnightTime() + 7 * 3600000)
+        sunTimes.sunset = new Date(getMidnightTime() + 19 * 3600000)
+    }
     state.sunTimes = [
     	sunrise: sunTimes.sunrise.time,
     	sunset: sunTimes.sunset.time,
@@ -1946,6 +1951,11 @@ private getSunTimes() {
     //we require an update every 8 hours
     if (!updated || (now() - updated < 28800000)) return state.sunTimes
     return initSunriseAndSunset()
+}
+
+private getMidnightTime(rtData) {
+	def rightNow = localTime()
+    return localToUtcTime(rightNow - rightNow.mod(86400000))
 }
 
 /******************************************************************************/


### PR DESCRIPTION
In some cases the `getSunriseAndSunset()` method can return null values for the sunrise and sunset, possibly related to not having a geographic location set for the hub. This fix logs a warning and uses 7 am and 7 pm in the local timezone as default values to avoid breaking anything that depends on sunrise and sunset times.

The NPE causes the dashboard to hang at the loading spinner. Anyone seeing the "Actual sunrise and sunset times are unavailable; please reset the location for your hub" warning should update the hub location in the SmartThings app. If a location is already specified, move the location and then move it back. When affected by this bug, SmartThings will not show a time zone for the location in the IDE.

Resolves an issue uncovered [here](https://community.webcore.co/t/dashboard-loads-but-pistons-wont/3908/) 