### PR TITLE
Fixes inability to load the dashboard in IE 11

### DIFF
--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -1881,4 +1881,14 @@ if (document.selection) {
      document.execCommand("Copy");
 }}
 
+// Polyfills
+if (!String.prototype.endsWith) {
+	String.prototype.endsWith = function(search, this_len) {
+		if (this_len === undefined || this_len > this.length) {
+			this_len = this.length;
+		}
+		return this.substring(this_len - search.length, this_len) === search;
+	};
+}
+
 version = function() { return 'v0.2.101.20171227'; };


### PR DESCRIPTION
Added a polyfill for `String.prototype.endsWith` to improve support for IE 11. I certainly cannot claim that IE 11 is fully supported but this allows `endsWith`, which is widely used in the dashboard, to work on older browsers. 