### PR TITLE
Enable custom fuel stream urls

### DIFF
--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -1333,21 +1333,51 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 	dataService.listFuelStreams = function() {
 		var instance = dataService.getInstance();
 		if (instance) {
-			var iid = instance.id;
-			var si = store[instance.id];
-			if (!si) si = {};
-			var region = (si && si.uri && si.uri.startsWith('https://graph-eu')) ? 'eu' : 'us';
-			var req = {
-				method: 'POST',
-				url: 'https://api-' + region + '-' + iid[32] + '.webcore.co:9287/fuelStreams/list',
-				headers: {
-				'Auth-Token': '|'+ iid
-				},
-				data: { i: iid }
+			var urls = instance.fuelStreamUrls;
+			var jsonp = false;
+			var req;
+			
+			if(urls){
+				var params = urls.list;
+				
+				if(params.l){
+					jsonp = true;
+					req = params.u;
+				}
+				else {
+					req = {
+						method: params.m,
+						url: params.u,
+						headers: params.h,
+						data: params.d
+					}
+				}
 			}
-			return $http(req).then(function(response) {
-					return response.data;
-				});
+			else {
+				var iid = instance.id;
+				var si = store[instance.id];
+				if (!si) si = {};
+				var region = (si && si.uri && si.uri.startsWith('https://graph-eu')) ? 'eu' : 'us';
+				req = {
+					method: 'POST',
+					url: 'https://api-' + region + '-' + iid[32] + '.webcore.co:9287/fuelStreams/list',
+					headers: {
+					'Auth-Token': '|'+ iid
+					},
+					data: { i: iid }
+				}				
+			}
+			
+			if(jsonp){
+				return $http.jsonp(req,{jsonpCallbackParam: 'callback'}).then(function(response) {
+						return response.data;
+					});
+			}
+			else {
+				return $http(req).then(function(response) {
+						return response.data;
+					});
+			}
 		}
 	}
 
@@ -1396,21 +1426,54 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 	dataService.listFuelStreamData = function(fuelStreamId) {
 		var instance = dataService.getInstance();
 		if (instance) {
-			var iid = instance.id;
-			var si = store[instance.id];
-			if (!si) si = {};
-			var region = (si && si.uri && si.uri.startsWith('https://graph-eu')) ? 'eu' : 'us';
-			var req = {
-				method: 'POST',
-				url: 'https://api-' + region + '-' + iid[32] + '.webcore.co:9287/fuelStreams/get',
-				headers: {
-				'Auth-Token': '|'+iid
-				},
-				data: { i: iid, f: fuelStreamId }
+			var urls = instance.fuelStreamUrls;
+			var jsonp = false;
+			var req;
+			
+			if(urls){
+				var params = urls.get;
+				
+				if(params.l){
+					jsonp = true;
+					req = params.u.replace("{" + params.p + "}", fuelStreamId);
+				}
+				else {
+					var data = params.d
+					data[params.p] = fuelStreamId;
+					
+					req = {
+						method: params.m,
+						url: params.u,
+						headers: params.h,
+						data: data
+					}
+				}
 			}
-			return $http(req).then(function(response) {
-					return response.data;
-				});
+			else {
+				var iid = instance.id;
+				var si = store[instance.id];
+				if (!si) si = {};
+				var region = (si && si.uri && si.uri.startsWith('https://graph-eu')) ? 'eu' : 'us';
+				req = {
+					method: 'POST',
+					url: 'https://api-' + region + '-' + iid[32] + '.webcore.co:9287/fuelStreams/get',
+					headers: {
+					'Auth-Token': '|'+iid
+					},
+					data: { i: iid, f: fuelStreamId }
+				}				
+			}
+			
+			if(jsonp){
+				return $http.jsonp(req,{jsonpCallbackParam: 'callback'}).then(function(response) {
+						return response.data;
+					});
+			}
+			else {
+				return $http(req).then(function(response) {
+						return response.data;
+					});
+			}
 		}
 	}
 

--- a/smartapps/ady624/webcore.src/webcore.groovy
+++ b/smartapps/ady624/webcore.src/webcore.groovy
@@ -909,12 +909,13 @@ private api_get_base_result(deviceVersion = 0, updateCache = false) {
 	def Boolean sendDevices = (deviceVersion != currentDeviceVersion)
     def name = handle() + ' Piston'
     def incidentThreshold = now() - 604800000
+    def instanceId = hashId(app.id, updateCache)
 	return [
         name: location.name + ' \\ ' + (app.label ?: app.name),
         instance: [
 	    	account: [id: hashId(hubUID ?: app.getAccountId(), updateCache)],
         	pistons: getChildApps().findAll{ it.name == name }.sort{ it.label }.collect{ [ id: hashId(it.id, updateCache), 'name': it.label, 'meta': state[hashId(it.id, updateCache)] ] },
-            id: hashId(app.id, updateCache),
+            id: instanceId,
             locationId: hashId(location.id, updateCache),
             name: app.label ?: app.name,
             uri: state.endpoint,
@@ -924,7 +925,8 @@ private api_get_base_result(deviceVersion = 0, updateCache = false) {
             settings: state.settings ?: [:],
             lifx: state.lifx ?: [:],
             virtualDevices: virtualDevices(updateCache),
-            globalVars: listAvailableVariables(),
+            globalVars: listAvailableVariables(),            
+            fuelStreamUrls: getFuelStreamUrls(instanceId),
         ] + (sendDevices ? [contacts: [:], devices: listAvailableDevices(false, updateCache)] : [:]),
         location: [
             contactBookEnabled: location.getContactBookEnabled(),
@@ -944,6 +946,17 @@ private api_get_base_result(deviceVersion = 0, updateCache = false) {
             zipCode: location.getZipCode(),
         ],
         now: now(),
+    ]
+}
+
+private getFuelStreamUrls(iid){
+    def region = state.endpoint.contains('graph-eu') ? 'eu' : 'us'
+    def baseUrl = 'https://api-' + region + '-' + iid[32] + '.webcore.co:9287/fuelStreams'
+    def headers = [ 'Auth-Token' : iid ]
+    
+    return [
+		list : [l: false, m: 'POST', h: headers, u: baseUrl + '/list', d: [i : iid]],
+        get  : [l: false, m: 'POST', h: headers, u: baseUrl + '/get',  d: [ i: iid ], p: 'f']
     ]
 }
 


### PR DESCRIPTION
Enable custom fuel stream url per our conversation on community.webcore.co to enable custom (local) urls to be sent to the UI.

Tested for backwards compatibility for both UI and backend.

Hubitat's version will have something like this in the getFuelStreamUrl's method

```
return [
		list : [l: true, u: baseUrl + "intf/fuelstreams/list?access_token=${state.accessToken}"],
                get  : [l: true, u: baseUrl + "intf/fuelstreams/get?id={fuelStreamId}&access_token=${state.accessToken}", p: 'fuelStreamId']
    ]
```