### PR TITLE
Restore from backup file

### DIFF
--- a/dashboard/css/app.css
+++ b/dashboard/css/app.css
@@ -518,10 +518,6 @@ error button {
 }
 
 
-.btn i {
-	height: 20px;
-	line-height: 20px;
-}
 
 
 label:not(.form-check-label) > input {

--- a/dashboard/html/modules/dashboard.module.html
+++ b/dashboard/html/modules/dashboard.module.html
@@ -409,7 +409,7 @@
 <designer ng-if="designer.page==1">
       <header ng-if="designer.type=='blank'">
           <h3>Create a new blank piston</h3>
-          <span>You are about to create a new piston from scratch. Yey! Click Create to get started.</span>
+          <span>You are about to create a new piston from scratch.</span>
       </header>
       <header ng-if="designer.type=='duplicate'">
           <h3>Create a duplicate piston</h3>
@@ -418,13 +418,30 @@
       <header ng-if="designer.type=='restore'">
           <h3>Restore a piston</h3>
           <span>Please enter the backup bin code below and click Create to get started.</span>
-          <p><b>NOTE:</b> Only backup bin codes created by your account are supported. All others will generate an empty piston.</p>
+          <p>You may restore public, anonymized backup codes shared by others or private backup codes created by your account. Private backup codes created by a different account cannot be restored.</p>
       </header>
       <header ng-if="designer.type=='import'">
-          <h3>Import a new piston</h3>
-          <span>You wanted to import a new piston. The bad news is, there is no way yet :( But the good news is, you can start one from scratch. Yey! Click Next to get started.</span>
+          <h3>Import a piston from a backup file</h3>
+          <span>Upload your backup file created by the Backup Pistons menu item on the dashboard then restore pistons.</span>
       </header>
-      <form>
+      <div ng-if="designer.type == 'import'">
+        <form ng-if="!importedPistons">
+          <div class="form-group">
+            <label for="backupFile">Backup file</label>
+            <input id="backupFile" name="backupFile" ng-model="designer.backupFile" type="file" accept=".backup" />
+          </div>
+        </form>
+        <ol ng-if="importedPistons">
+          <li ng-repeat="data in importedPistons">
+            <button class="btn btn-sm btn-primary pull-right" ng-click="restoreImportedPiston(data)">Restore</button>
+            <strong>{{data.meta.name}}</strong>
+            <p>
+              Created by {{data.meta.author}} on {{data.meta.created | date}}
+            </p>
+          </li>
+        </ol>
+      </div>
+      <form ng-if="designer.type != 'import'">
           <div class="form-group">
 	            <label for="author">Author</label>
                   <input class="form-control"  id="author" ng-model="designer.author" type="text" />
@@ -484,7 +501,8 @@
       </form>
 
       <footer>
-          <button type="button" class="btn btn-info pull-right" ng-disabled="!designer.type || !designer.author || !designer.name || ((designer.type == 'duplicate') && !designer.piston) || ((designer.type == 'restore') && !designer.bin)" ng-click="createPiston();">Create</button>
+          <button ng-if="designer.type != 'import'" type="button" class="btn btn-info pull-right" ng-disabled="!designer.type || !designer.author || !designer.name || ((designer.type == 'duplicate') && !designer.piston) || ((designer.type == 'restore') && !designer.bin)" ng-click="createPiston();">Create</button>
+          <button ng-if="designer.type == 'import' && !importedPistons" type="button" class="btn btn-info pull-right" ng-click="loadBackupFile();">Import</button>
           <button type="button" class="btn btn-default" ng-click="prevPage();">Back</button>
       </footer>
   </designer>

--- a/dashboard/html/modules/dashboard.module.html
+++ b/dashboard/html/modules/dashboard.module.html
@@ -449,6 +449,10 @@
               <button type="button" class="btn btn-sm btn-primary pull-right" ng-show="!!data.imported" ng-click="openPiston(data.imported); closeDialog()">View</button>
               <button class="btn btn-sm pull-right" ng-class="data.imported ? 'btn-secondary' : 'btn-primary'" ng-click="restoreImportedPiston(data)">Restore {{data.imported ? ' again' : ''}}</button>
               <strong>{{data.meta.name}}</strong>
+              <div ng-if="data.warnings && data.warnings.length" class="text-warning">
+                <i class="fas fa-exclamation-triangle"></i>
+                {{data.warnings.join(', ')}}
+              </div>
               <p>
                 Created by {{data.meta.author}} on {{data.meta.created | date}}
               </p>

--- a/dashboard/html/modules/dashboard.module.html
+++ b/dashboard/html/modules/dashboard.module.html
@@ -503,6 +503,7 @@
       <footer>
           <button ng-if="designer.type != 'import'" type="button" class="btn btn-info pull-right" ng-disabled="!designer.type || !designer.author || !designer.name || ((designer.type == 'duplicate') && !designer.piston) || ((designer.type == 'restore') && !designer.bin)" ng-click="createPiston();">Create</button>
           <button ng-if="designer.type == 'import' && !importedPistons" type="button" class="btn btn-info pull-right" ng-click="loadBackupFile();">Import</button>
+          <button ng-if="designer.type == 'import' && importedPistons" type="button" class="btn btn-info pull-right" ng-click="restartPistonImport();">New import</button>
           <button type="button" class="btn btn-default" ng-click="prevPage();">Back</button>
       </footer>
   </designer>

--- a/dashboard/html/modules/dashboard.module.html
+++ b/dashboard/html/modules/dashboard.module.html
@@ -421,25 +421,40 @@
           <p>You may restore public, anonymized backup codes shared by others or private backup codes created by your account. Private backup codes created by a different account cannot be restored.</p>
       </header>
       <header ng-if="designer.type=='import'">
-          <h3>Import a piston from a backup file</h3>
-          <span>Upload your backup file created by the Backup Pistons menu item on the dashboard then restore pistons.</span>
+          <h3>Import pistons from a backup file</h3>
       </header>
       <div ng-if="designer.type == 'import'">
         <form ng-if="!importedPistons">
+          <p>Upload your backup file created by the Backup Pistons menu item on the dashboard then restore pistons.</p>
           <div class="form-group">
             <label for="backupFile">Backup file</label>
             <input id="backupFile" name="backupFile" ng-model="designer.backupFile" type="file" accept=".backup" />
           </div>
         </form>
-        <ol ng-if="importedPistons">
-          <li ng-repeat="data in importedPistons">
-            <button class="btn btn-sm btn-primary pull-right" ng-click="restoreImportedPiston(data)">Restore</button>
-            <strong>{{data.meta.name}}</strong>
-            <p>
-              Created by {{data.meta.author}} on {{data.meta.created | date}}
-            </p>
-          </li>
-        </ol>
+        <div ng-if="importedPistons">
+          <p>The following pistons were included in the backup file. Pistons that you have already restored and existing pistons with a name matching the backup file are displayed at the end of the list.</p>
+          <div class="pull-right form-group form-group-sm form-inline">
+            <label for="import-sort" class="small">Sort by</label>
+            <select id="import-sort" ng-model="importedPistonsSortOrder" ng-change="sortImportedPistons(importedPistonsSortOrder)" class="form-control">
+              <option>safest</option>
+              <option>name</option>
+              <option>category</option>
+              <option>created date</option>
+              <option>last modified</option>
+            </select>
+          </div>
+          <p>Some pistons in this list may show warnings to identify factors that may need to be reviewed when you import the piston. The "safest" sort order shows pistons with the fewest warnings first. Sorry, we can't restore categories, global variables, places, or other global settings... yet.</p>
+          <ol>
+            <li ng-repeat="data in importedPistons track by data.meta.id" ng-class="{ 'text-muted': !!data.imported }">
+              <button type="button" class="btn btn-sm btn-primary pull-right" ng-show="!!data.imported" ng-click="openPiston(data.imported); closeDialog()">View</button>
+              <button class="btn btn-sm pull-right" ng-class="data.imported ? 'btn-secondary' : 'btn-primary'" ng-click="restoreImportedPiston(data)">Restore {{data.imported ? ' again' : ''}}</button>
+              <strong>{{data.meta.name}}</strong>
+              <p>
+                Created by {{data.meta.author}} on {{data.meta.created | date}}
+              </p>
+            </li>
+          </ol>
+        </div>
       </div>
       <form ng-if="designer.type != 'import'">
           <div class="form-group">

--- a/dashboard/html/modules/dashboard.module.html
+++ b/dashboard/html/modules/dashboard.module.html
@@ -449,8 +449,11 @@
           <p>Some pistons in this list may show warnings to identify factors that may need to be reviewed when you import the piston. The "safest" sort order shows pistons with the fewest warnings first. Sorry, we can't restore categories, global variables, places, or other global settings... yet.</p>
           <ol>
             <li ng-repeat="data in importedPistons track by data.meta.id" ng-class="{ 'text-muted': !!data.imported }">
-              <button type="button" class="btn btn-sm btn-primary pull-right" ng-show="!!data.imported" ng-click="openPiston(data.imported); closeDialog()">View</button>
-              <button class="btn btn-sm pull-right" ng-class="data.imported ? 'btn-secondary' : 'btn-primary'" ng-click="restoreImportedPiston(data)">Restore {{data.imported ? ' again' : ''}}</button>
+              <div class="btn-group btn-group-sm pull-right">
+                <button class="btn btn-sm" ng-class="data.imported ? 'btn-secondary' : 'btn-primary'" ng-click="restoreImportedPiston(data)">Restore {{data.imported ? ' again' : ''}}</button>
+                <button type="button" class="btn btn-sm btn-primary" ng-show="!!data.imported" ng-click="openPiston(data.imported); closeDialog()">View</button>
+                <button type="button" class="btn btn-sm btn-white" ng-click="removeImportedPiston(data.meta.id)"><i class="far fa-times fa-sm"></i></button>
+              </div>
               <strong>{{data.meta.name}}</strong>
               <div ng-if="data.warnings && data.warnings.length" class="text-warning">
                 <i class="fas fa-exclamation-triangle"></i>

--- a/dashboard/html/modules/dashboard.module.html
+++ b/dashboard/html/modules/dashboard.module.html
@@ -172,6 +172,9 @@
 					<incident ng-repeat="incident in location.incidents" source-type="{{incident.sourceType}}" ng-bind-html="renderIncident(incident)"></incident>
 				</div>
 				<div class="no-animate alert alert-warning" ng-if="instance && permanentStatus" role="alert" ng-bind-html="permanentStatus"></div>
+				<div warning ng-if="canResumeImport" class="alert alert-info">
+					Would you like to resume importing pistons? <a href="#" ng-click="resumeImport()" class="alert-link">Continue your import</a> or if the import is complete <a href="#" ng-click="restartPistonImport()" class="alert-link">reset import data</a>
+				</div>
 				<div class="table-responsive no-animate" ng-repeat="category in categories" ng-if="instance && category.p && category.p.length && (category.t != 'h')">
 					<label ng-if="category.n">{{category.n}} ({{category.p.length}})</label>
 					<table class="table" ng-if="(category.t == 'd') || (category.t == 'dt') || (category.t == 'dm') || (category.t == 'dl')">
@@ -568,6 +571,7 @@
 <designer>
       <header>
           <h3>Backup piston(s)</h3>
+          <span>Use the New Piston button to restore pistons from a backup file. Note that categories, global variables, places, and other global settings are not included in the backup at this time.</span>
       </header>
 	<form ng-if="designer.page==0">
 		<div class="form-group">

--- a/dashboard/html/modules/piston.module.html
+++ b/dashboard/html/modules/piston.module.html
@@ -123,6 +123,10 @@
 
 	<div class="container" ng-if="mode=='view'">
 		
+		<div warning ng-if="canResumeImport" class="alert alert-info">
+			After reviewing this piston, <a href="#" ng-click="resumeImport()" class="alert-link">continue your import</a>
+		</div>
+		
 		<div warning ng-if="meta.active && !subscriptions.events && !schedules.length && !piston.o.des" class="alert alert-warning">This piston does not subscribe to any events. Unless executed by other means, it will never run on its own.</div>
 
 		<div class="text-right">

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -1106,9 +1106,22 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
         });
     }
     
+    dataService.getImportedData = function() {
+      return localforage.getItem('import');
+    }
+    
+    dataService.setImportedData = function(importedData) {
+      return localforage.setItem('import', importedData);
+    }
+    
+    dataService.clearImportedData = function() {
+      return localforage.removeItem('import');
+    }
+    
     dataService.loadFromImport = function (pistonId) {
       status('Loading piston from import...');
       return $q.resolve(localforage.getItem('import')).then(function(pistons) {
+        status();
         if (pistons && pistons.length > 0) {
           return pistons.find(function(data) {
             return data.meta.id === pistonId;

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -587,6 +587,10 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 		return encryptObject(obj, _ek + (password ? password : ''));
 	}
 
+	dataService.decryptBackup = function(obj, password) {
+		return decryptObject(obj, _ek + (password ? password : ''));
+	}
+
     var decryptObject = function(data, ek) {
         try {
             return angular.fromJson($window.sjcl.decrypt(ek ? ek : _ek, atou(data)));
@@ -1100,6 +1104,17 @@ config.factory('dataService', ['$http', '$location', '$rootScope', '$window', '$
 				return null;
 			}
         });
+    }
+    
+    dataService.loadFromImport = function (pistonId) {
+      status('Loading piston from import...');
+      return $q.resolve(localforage.getItem('import')).then(function(pistons) {
+        if (pistons && pistons.length > 0) {
+          return pistons.find(function(data) {
+            return data.meta.id === pistonId;
+          }) || null;
+        }
+      });
     }
 
 

--- a/dashboard/js/modules/dashboard.module.js
+++ b/dashboard/js/modules/dashboard.module.js
@@ -712,6 +712,16 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 			});
 	}
 	
+	$scope.removeImportedPiston = function(pistonId) {
+		for (var i = 0; i < $scope.importedPistons.length; i++) {
+			if ($scope.importedPistons[i].meta.id === pistonId) {
+				$scope.importedPistons.splice(i, 1);
+				break;
+			}
+		}
+		return dataService.setImportedData($scope.importedPistons);
+	}
+	
 	$scope.sortImportedPistons = function(order) {
 		$scope.importedPistonsSortOrder = $scope.importedPistonsSortOrder || 'safest';
 		$scope.importedPistons.sort(function(a, b) { 

--- a/dashboard/js/modules/dashboard.module.js
+++ b/dashboard/js/modules/dashboard.module.js
@@ -915,6 +915,11 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 		};
 		reader.readAsText(file);
 	};
+	
+	$scope.restartPistonImport = function() {
+		localforage.removeItem('import');
+		$scope.importedPistons = null;
+	};
 
 
 	$scope.getOpacity = function(time) {

--- a/dashboard/js/modules/dashboard.module.js
+++ b/dashboard/js/modules/dashboard.module.js
@@ -677,7 +677,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 	        });
 		});
 		
-		localforage.getItem('import').then(function(importedPistons) {
+		dataService.getImportedData().then(function(importedPistons) {
 			$scope.importedPistons = importedPistons;
 			$scope.sortImportedPistons();
 		});
@@ -692,7 +692,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 				// Mark piston as imported and cycle it to the end of the array
 				data.imported = piston.id;
 				data.importedAt = Date.now();
-				localforage.setItem('import', $scope.importedPistons);
+				dataService.setImportedData($scope.importedPistons);
 			});
 	}
 	
@@ -965,7 +965,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 						}
 					}
 					
-					localforage.setItem('import', data);
+					dataService.setImportedData(data);
 					$scope.importedPistons = data;
 					$scope.sortImportedPistons();
 				}
@@ -975,7 +975,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 	};
 	
 	$scope.restartPistonImport = function() {
-		localforage.removeItem('import');
+		dataService.clearImportedData();
 		$scope.importedPistons = null;
 	};
 

--- a/dashboard/js/modules/dashboard.module.js
+++ b/dashboard/js/modules/dashboard.module.js
@@ -679,6 +679,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 		
 		localforage.getItem('import').then(function(importedPistons) {
 			$scope.importedPistons = importedPistons;
+			$scope.sortImportedPistons();
 		});
     };
 		
@@ -693,6 +694,28 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 				data.importedAt = Date.now();
 				localforage.setItem('import', $scope.importedPistons);
 			});
+	}
+	
+	$scope.sortImportedPistons = function(order) {
+		$scope.importedPistonsSortOrder = $scope.importedPistonsSortOrder || 'safest';
+		$scope.importedPistons.sort(function(a, b) { 
+			var xorImported = !!a.imported - !!b.imported;
+			if (xorImported) return xorImported;
+			
+			switch (order) {
+				case 'category':
+					return (a.meta.category || Infinity) - (b.meta.category || Infinity);
+				case 'name':
+					return a.meta.name.localeCompare(b.meta.name);
+				case 'created':
+					return a.meta.created - b.meta.created;
+				case 'modified':
+					return (a.meta.modified || a.meta.created) - (b.meta.modified || b.meta.created);
+				default:
+					return a.imported ? (a.importedAt - b.importedAt) : (a.warningLevel - b.warningLevel || a.meta.name.localeCompare(b.meta.name))
+					break;
+			}
+		});
 	}
 
 
@@ -927,6 +950,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 					
 					localforage.setItem('import', data);
 					$scope.importedPistons = data;
+					$scope.sortImportedPistons();
 				}
 			}
 		};

--- a/dashboard/js/modules/piston.module.js
+++ b/dashboard/js/modules/piston.module.js
@@ -291,7 +291,7 @@ config.controller('piston', ['$scope', '$rootScope', 'dataService', '$timeout', 
 									$scope.loading = true;
 									getPiston = $q.all([
 										dataService.loadFromImport($scope.params.piston),
-										localforage.getItem('import')
+										dataService.getImportedData()
 									]).then(function (results) {
 										var pistonData = results[0];
 										var importData = results[1];

--- a/dashboard/js/modules/piston.module.js
+++ b/dashboard/js/modules/piston.module.js
@@ -266,50 +266,54 @@ config.controller('piston', ['$scope', '$rootScope', 'dataService', '$timeout', 
 					$scope.piston.z = $scope.params && $scope.params.description ? $scope.params.description : '';
 					$scope.mode = 'edit';
 					if ($scope.params && $scope.params.type != 'blank') {
+						var getPiston;
 						switch ($scope.params.type) {
 							case 'duplicate':
 								if ($scope.params.piston) {
 									$scope.loading = true;
-									dataService.getPiston($scope.params.piston).then(function (response) {
-										$scope.loading = false;
-										if (response && response.data && response.data.piston) {
-											$scope.piston.o = response.data.piston.o ? response.data.piston.o : {};
-											$scope.piston.r = response.data.piston.r ? response.data.piston.r : [];
-											$scope.piston.rn = !!response.data.piston.rn;
-											$scope.piston.rop = response.data.piston.rop ? response.data.piston.rop : 'and';
-											$scope.piston.s = response.data.piston.s ? response.data.piston.s : [];
-											$scope.piston.v = response.data.piston.v ? response.data.piston.v : [];
-										}
-										$scope.initialized = true;
-										$scope.loading = false;
+									getPiston = dataService.getPiston($scope.params.piston).then(function (response) {
+										// Do not trigger a rebuild
+										delete response.data.l;
+										return response.data;
 									});
-									return;
 								}
 								break;
 							case 'restore':
 								if ($scope.params.bin) {
 									$scope.loading = true;
-									dataService.loadFromBin($scope.params.bin).then(function (response) {
-										var piston = response.data;
-										$scope.loading = false;
-										if (piston) {
-											$scope.piston.o = piston.o ? piston.o : {};
-											$scope.piston.r = piston.r ? piston.r : [];
-											$scope.piston.rn = !!piston.rn;
-											$scope.piston.rop = piston.rop ? piston.rop : 'and';
-											$scope.piston.s = piston.s ? piston.s : [];
-											$scope.piston.v = piston.v ? piston.v : [];
-											$scope.piston.z = piston.z ? piston.z : '';
-										}
-										$scope.initialized = true;
-										$scope.loading = false;
-										if (!!piston && (piston.l instanceof Object) && ($scope.objectToArray(piston.l).length)) {
-											$scope.rebuildPiston(piston.l);
-										}
+									getPiston = dataService.loadFromBin($scope.params.bin).then(function (response) {
+										return response.data;
 									});
-									return;
 								}
 								break;
+							case 'import':
+								if ($scope.params.piston) {
+									$scope.loading = true;
+									getPiston = dataService.loadFromImport($scope.params.piston).then(function (data) {
+										return data.piston;
+									});
+								}
+								break;
+						}
+						
+						if (getPiston) {
+							getPiston.then(function(piston) {
+								if (piston) {
+									$scope.piston.o = piston.o ? piston.o : {};
+									$scope.piston.r = piston.r ? piston.r : [];
+									$scope.piston.rn = !!piston.rn;
+									$scope.piston.rop = piston.rop ? piston.rop : 'and';
+									$scope.piston.s = piston.s ? piston.s : [];
+									$scope.piston.v = piston.v ? piston.v : [];
+									$scope.piston.z = piston.z ? piston.z : '';
+									
+									if ((piston.l instanceof Object) && ($scope.objectToArray(piston.l).length)) {
+										$scope.rebuildPiston(piston.l);
+									}
+								}
+								$scope.initialized = true;
+								$scope.loading = false;
+							});
 						}
 					}
 				}

--- a/dashboard/js/modules/piston.module.js
+++ b/dashboard/js/modules/piston.module.js
@@ -33,6 +33,9 @@ config.controller('piston', ['$scope', '$rootScope', 'dataService', '$timeout', 
 	};
 	$scope.weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 	$scope.yearMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+	dataService.getImportedData().then(function(data) {
+		$scope.canResumeImport = data && data.length;
+	});
 
 	$scope.render = function(cancelTimer) {
 		//do nothing, but rerenders
@@ -619,6 +622,12 @@ config.controller('piston', ['$scope', '$rootScope', 'dataService', '$timeout', 
 			$location.path('/');
 		});
 	}
+	
+	$scope.resumeImport = function() {
+		$rootScope.dashboardResumeImport = true;
+		$location.path('/');
+	}
+	
 	$scope.padComment = function(comment, sz) {
 		if (!comment) comment = '';
 		//replace LEFT-TO-RIGHT marks \u200E - Edge keeps adding them to date/times


### PR DESCRIPTION
This feature is in progress and was migrated from the dev branch to a pull request to prevent interruption of other development and bug fixes. Much work is needed still but what is complete has been tested out by a few webCoRE users who needed to restore pistons from backup.

### Backup file

- [ ] Update backup file to include instance-level data including 
    - [ ] categories
    - [ ] global variables
    - [ ] places
    - [ ] integrations
    - [ ] devices

### Multi-step restore

- [X] Client-side file reading and password prompt to decrypt backup file
- [X] Indicate pistons that already exist (exact name match) or that have been imported in this batch (resilient to renames)
- [X] Allow imported data to be erased and a new file imported
- [ ] More convenient way to return to the import list than New Piston > Import pistons
- [ ] Indicate any devices that do not exist yet so that user can authorize them before continuing
- [ ] Restore selected global variables
- [ ] Restore selected categories, places, integrations
- [ ] Restore selected piston metadata (name, category, description) in paused state with no data
- [ ] Restore piston data (automatically if possible but may have to be saved one-by-one)
    - [x] Automatic migration of piston IDs in Execute Piston actions
    - [ ] Global migration of missing devices