### PR TITLE
Allow for user defined headers in HTTP requests.

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3264,7 +3264,7 @@ private long vcmd_httpRequest(rtData, device, params) {
 				headers: [
 					HOST: userPart + ip,
 					'Content-Type': requestContentType
-				] + (auth ? [Authorization: auth] : [:]),
+				] + (auth ? (auth.contains(':') ? ( new groovy.json.JsonSlurper().parseText("{"+auth+"}") ) : [Authorization : auth]) : [:]),
 				query: useQueryString ? data : null, //thank you @destructure00
 				body: !useQueryString ? data : null //thank you @destructure00
 			]
@@ -3279,7 +3279,7 @@ private long vcmd_httpRequest(rtData, device, params) {
 			def requestParams = [
 				uri:  "${protocol}://${userPart}${uri}",
 				query: useQueryString ? data : null,
-                headers: (auth ? [Authorization: auth] : [:]),
+                                headers: (auth ? (auth.contains(':') ? ( new groovy.json.JsonSlurper().parseText("{"+auth+"}") ) : [Authorization : auth]) : [:]),
 				requestContentType: requestContentType,
 				body: !useQueryString ? data : null
 			]

--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -3264,7 +3264,7 @@ private long vcmd_httpRequest(rtData, device, params) {
 				headers: [
 					HOST: userPart + ip,
 					'Content-Type': requestContentType
-				] + (auth ? (auth.contains(':') ? ( new groovy.json.JsonSlurper().parseText("{"+auth+"}") ) : [Authorization : auth]) : [:]),
+				] + (auth ? ((auth.startsWith('{') && auth.endsWith('}')) ? ( new groovy.json.JsonSlurper().parseText( auth ) ) : [Authorization : auth]) : [:]),
 				query: useQueryString ? data : null, //thank you @destructure00
 				body: !useQueryString ? data : null //thank you @destructure00
 			]
@@ -3279,7 +3279,7 @@ private long vcmd_httpRequest(rtData, device, params) {
 			def requestParams = [
 				uri:  "${protocol}://${userPart}${uri}",
 				query: useQueryString ? data : null,
-                                headers: (auth ? (auth.contains(':') ? ( new groovy.json.JsonSlurper().parseText("{"+auth+"}") ) : [Authorization : auth]) : [:]),
+				headers: (auth ? ((auth.startsWith('{') && auth.endsWith('}')) ? ( new groovy.json.JsonSlurper().parseText( auth ) ) : [Authorization : auth]) : [:]),
 				requestContentType: requestContentType,
 				body: !useQueryString ? data : null
 			]


### PR DESCRIPTION
User can use a JSON map defined to insert additional headers. Hack is backwards compatible as it looks for a colon : that should not be used in base64 encoding required for the 'authorization' header. Example:
"x-api-key" : "{apikey}", "authorization" : "{apikey}", "Public-Key-Pins": "max-age=2592000; pin-sha256=\\"E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=\\";"