### PR TITLE
Remove visor module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,6 @@
 ######################
 *.sh
 
-######################
-# Visor              #
-######################
-visor*
-dist/visor*
 dashboard/fa*
 dashboard/mp3*
 dashboard/js/components/fa*

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -48,7 +48,6 @@
 		<script type="text/javascript" src="js/modules/dashboard.module.js" charset="utf-8"></script><!--dev-->
 		<script type="text/javascript" src="js/modules/piston.module.js" charset="utf-8"></script><!--dev-->
 		<script type="text/javascript" src="js/modules/fuel.module.js" charset="utf-8"></script><!--dev-->
-		<script type="text/javascript" src="js/modules/visors.module.js" charset="utf-8"></script><!--dev-->
 		<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 		<script defer src="https://kit.fontawesome.com/a00a53f405.js" crossorigin="anonymous" onerror="loadFontAwesomeFallback()"></script>
 		<script defer src="https://pro.fontawesome.com/releases/v5.11.1/js/v4-shims.js" crossorigin="anonymous"></script>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -484,11 +484,6 @@ var config = app.config(['$routeProvider', '$locationProvider', '$sceDelegatePro
         controller: 'fuel',
         css: cdn + theme + 'css/modules/fuel' + ext + '?v=' + version()
     }).
-    when('/visors', {
-        templateUrl: cdn + theme + 'html/modules/visors.module.html?v=' + version(),
-        controller: 'visors',
-        css: cdn + theme + 'css/modules/visors' + ext + '?v=' + version()
-    }).
     when('/init/:instId1/:instId2', {
         redirectTo: function(params) {
 			app.initialInstanceUri = atou(params.instId1 + '/' +  params.instId2);


### PR DESCRIPTION
Files from this module were removed on https://github.com/ady624/webCoRE/commit/24bd06f0986c3b6416f5a353640d7ae488f4fa79 but these entries were never removed.

Unless this is a future plan... But, currently, dashboard handles inclusion of `visors.module.js` as a 404.